### PR TITLE
Do not show sidebar drop shadow on small/medium screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Removed sidebar drop shadow on screens where it's closed by default (small/medium size screens) in order to avoid having a shadow visible to the left of the screen even when the menu is closed on mobile/tablet
 - Fixed a problem where menu-open would be added to menu items without children
 - Menu styling is now using different colors for hovering and normal state
 

--- a/styles/Layout/SideBarLayout.scss
+++ b/styles/Layout/SideBarLayout.scss
@@ -66,7 +66,10 @@ $topnav-light-toggler-color: $gray-900;
     z-index: $zindex-sidenav;
     // Mobile first transform - by default the sidenav will be moved off-canvas
     transform: translateX(-$sidenav-base-width);
-    box-shadow: 0 0 0.5rem 0.125rem rgba($color: $gray-500, $alpha: 0.75);
+
+    @include media-breakpoint-up(lg) {
+      box-shadow: 0 0 0.5rem 0.125rem rgba($color: $gray-500, $alpha: 0.75);
+    }
   }
 
   &__content {


### PR DESCRIPTION
removed sidebar drop shadow on screens where
it's not open by default (small/medium size screens)