### PR TITLE
Fix paging overflow and text placement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed row size and overflow behaviour for Paging component so that it does not always show a horizontal scrollbar regardless of the available width
+- The paging text will now occupy the whole row in case there are no page buttons to be rendered
+
 ## [2.8.1] - 2023-09-19
 
 ### Fixed

--- a/cypress/cypress/component/Paging/Paging.cy.tsx
+++ b/cypress/cypress/component/Paging/Paging.cy.tsx
@@ -22,14 +22,14 @@ describe("Paging.cy.tsx", () => {
     );
 
     // Check pages per item dropdown
-    cy.get("[data-cy-root] > .row > .col-6:first-of-type > .btn-group > button.dropdown-toggle")
+    cy.get("[data-cy-root] > .container-fluid > .row > .col-6:first-of-type > .btn-group > button.dropdown-toggle")
       .should("have.text", itemsPerPage.toString())
       .click();
-    cy.get("[data-cy-root] > .row > .col-6:first-of-type > .btn-group > .dropdown-menu > h6").should(
+    cy.get("[data-cy-root] > .container-fluid > .row > .col-6:first-of-type > .btn-group > .dropdown-menu > h6").should(
       "have.text",
       translations.itemsPerPageDropdown,
     );
-    cy.get("[data-cy-root] > .row > .col-6:first-of-type > .btn-group > .dropdown-menu > .dropdown-item").then(
+    cy.get("[data-cy-root] > .container-fluid > .row > .col-6:first-of-type > .btn-group > .dropdown-menu > .dropdown-item").then(
       (items: JQuery<HTMLElement>) => {
         expect(items.map((_, item) => item.innerText).toArray(), "possible items per page").to.deep.eq(
           [25, 50, 100, 200, itemsPerPage].sort((a, b) => a - b).map((itemNumber): string => itemNumber.toString()),
@@ -40,7 +40,7 @@ describe("Paging.cy.tsx", () => {
     );
 
     // Check current page/items text
-    cy.get("[data-cy-root] > .row > .col-6:first-of-type > span.small").should(
+    cy.get("[data-cy-root] > .container-fluid > .row > .col-6:first-of-type > span.small").should(
       "have.text",
       translations.showedItemsText
         .replace("{from}", (currentPage * itemsPerPage - itemsPerPage + 1).toString())
@@ -49,18 +49,20 @@ describe("Paging.cy.tsx", () => {
     );
 
     // Check pagination buttons
-    cy.get("[data-cy-root] > .row > .col-6:nth-of-type(2) > .btn-group > button.btn").then((items: JQuery<HTMLElement>) => {
-      expect(items.length, "navigation buttons count").to.eq(Math.min(7, pages) + 4);
-      cy.wrap(items.filter((_, item) => item.innerText === "<<")).click();
-      cy.get("@setCurrentPage").should("be.calledOnceWith", 1);
-      cy.wrap(items.filter((_, item) => item.innerText === "<")).click();
-      cy.get("@setCurrentPage").should("be.calledWith", currentPage - 1);
-      cy.wrap(items.filter((_, item) => item.innerText === (currentPage - 1).toString())).click();
-      cy.get("@setCurrentPage").should("be.calledWith", currentPage - 1);
-      cy.wrap(items.filter((_, item) => item.innerText === ">")).click();
-      cy.get("@setCurrentPage").should("be.calledWith", currentPage + 1);
-      cy.wrap(items.filter((_, item) => item.innerText === ">>")).click();
-      cy.get("@setCurrentPage").should("be.calledWith", pages);
-    });
+    cy.get("[data-cy-root] > .container-fluid > .row > .col-6:nth-of-type(2) > .btn-group > button.btn").then(
+      (items: JQuery<HTMLElement>) => {
+        expect(items.length, "navigation buttons count").to.eq(Math.min(7, pages) + 4);
+        cy.wrap(items.filter((_, item) => item.innerText === "<<")).click();
+        cy.get("@setCurrentPage").should("be.calledOnceWith", 1);
+        cy.wrap(items.filter((_, item) => item.innerText === "<")).click();
+        cy.get("@setCurrentPage").should("be.calledWith", currentPage - 1);
+        cy.wrap(items.filter((_, item) => item.innerText === (currentPage - 1).toString())).click();
+        cy.get("@setCurrentPage").should("be.calledWith", currentPage - 1);
+        cy.wrap(items.filter((_, item) => item.innerText === ">")).click();
+        cy.get("@setCurrentPage").should("be.calledWith", currentPage + 1);
+        cy.wrap(items.filter((_, item) => item.innerText === ">>")).click();
+        cy.get("@setCurrentPage").should("be.calledWith", pages);
+      },
+    );
   });
 });

--- a/src/lib/Paging/Paging.tsx
+++ b/src/lib/Paging/Paging.tsx
@@ -45,66 +45,68 @@ function Paging({
   );
 
   return (
-    <Row style={{ marginBottom: "20px" }}>
-      <Col xs={6}>
-        {pagingPossible && (
-          <UncontrolledButtonDropdown>
-            <DropdownToggle caret color="link" size="sm">
-              {currentItemsPerPage}
-            </DropdownToggle>
-            <DropdownMenu>
-              <DropdownItem header>{translations.itemsPerPageDropdown}</DropdownItem>
-              {possibleItemsPerPage.map((pageItemCount) => (
-                <DropdownItem key={`pageItemCount_${pageItemCount}`} onClick={() => setItemsPerPage(pageItemCount)}>
-                  {pageItemCount}
-                </DropdownItem>
-              ))}
-            </DropdownMenu>
-          </UncontrolledButtonDropdown>
-        )}
-        <span className="small ml-2">
-          {translations.showedItemsText
-            .replace("{from}", ((currentPage - 1) * currentItemsPerPage + 1).toString())
-            .replace("{to}", ((currentPage - 1) * currentItemsPerPage + currentRecordCount).toString())
-            .replace("{total}", totalRecords.toString())}
-        </span>
-      </Col>
-
-      {pagingPossible && currentItemsPerPage < totalRecords && (
-        <Col xs={6} style={{ textAlign: "right" }}>
-          <ButtonGroup size="sm">
-            {showControls && (
-              <Button color="secondary" outline disabled={currentPage === 1} onClick={() => setCurrentPage(1)}>
-                {"<<"}
-              </Button>
-            )}
-            {showControls && (
-              <Button color="secondary" outline disabled={currentPage === 1} onClick={() => setCurrentPage(currentPage - 1)}>
-                {"<"}
-              </Button>
-            )}
-            {Array.from(Array(maxPage + 1).keys())
-              .filter((page) => page > firstPageShown)
-              .slice(0, maxPagesShown)
-              .map((page) => (
-                <Button key={page} outline={currentPage !== page} color="secondary" onClick={() => setCurrentPage(page)}>
-                  {page}
-                </Button>
-              ))}
-            {showControls && (
-              <Button color="secondary" outline disabled={currentPage === maxPage} onClick={() => setCurrentPage(currentPage + 1)}>
-                {">"}
-              </Button>
-            )}
-            {showControls && (
-              <Button color="secondary" outline disabled={currentPage === maxPage} onClick={() => setCurrentPage(maxPage)}>
-                {">>"}
-              </Button>
-            )}
-          </ButtonGroup>
+    <div className="container-fluid">
+      <Row style={{ marginBottom: "20px" }}>
+        <Col xs={pagingPossible && currentItemsPerPage < totalRecords ? 6 : 12} style={{ paddingLeft: 0 }}>
+          {pagingPossible && (
+            <UncontrolledButtonDropdown>
+              <DropdownToggle caret color="link" size="sm">
+                {currentItemsPerPage}
+              </DropdownToggle>
+              <DropdownMenu>
+                <DropdownItem header>{translations.itemsPerPageDropdown}</DropdownItem>
+                {possibleItemsPerPage.map((pageItemCount) => (
+                  <DropdownItem key={`pageItemCount_${pageItemCount}`} onClick={() => setItemsPerPage(pageItemCount)}>
+                    {pageItemCount}
+                  </DropdownItem>
+                ))}
+              </DropdownMenu>
+            </UncontrolledButtonDropdown>
+          )}
+          <span className="small ml-2">
+            {translations.showedItemsText
+              .replace("{from}", ((currentPage - 1) * currentItemsPerPage + 1).toString())
+              .replace("{to}", ((currentPage - 1) * currentItemsPerPage + currentRecordCount).toString())
+              .replace("{total}", totalRecords.toString())}
+          </span>
         </Col>
-      )}
-    </Row>
+
+        {pagingPossible && currentItemsPerPage < totalRecords && (
+          <Col xs={6} style={{ textAlign: "right", paddingRight: 0 }}>
+            <ButtonGroup size="sm">
+              {showControls && (
+                <Button color="secondary" outline disabled={currentPage === 1} onClick={() => setCurrentPage(1)}>
+                  {"<<"}
+                </Button>
+              )}
+              {showControls && (
+                <Button color="secondary" outline disabled={currentPage === 1} onClick={() => setCurrentPage(currentPage - 1)}>
+                  {"<"}
+                </Button>
+              )}
+              {Array.from(Array(maxPage + 1).keys())
+                .filter((page) => page > firstPageShown)
+                .slice(0, maxPagesShown)
+                .map((page) => (
+                  <Button key={page} outline={currentPage !== page} color="secondary" onClick={() => setCurrentPage(page)}>
+                    {page}
+                  </Button>
+                ))}
+              {showControls && (
+                <Button color="secondary" outline disabled={currentPage === maxPage} onClick={() => setCurrentPage(currentPage + 1)}>
+                  {">"}
+                </Button>
+              )}
+              {showControls && (
+                <Button color="secondary" outline disabled={currentPage === maxPage} onClick={() => setCurrentPage(maxPage)}>
+                  {">>"}
+                </Button>
+              )}
+            </ButtonGroup>
+          </Col>
+        )}
+      </Row>
+    </div>
   );
 }
 


### PR DESCRIPTION
- fixed row size and overflow behaviour for Paging component so that it does not always show a horizontal scrollbar regardless of the available width (for example, when wrapping a table inside a div with `overflow` property set to `auto`);
- paging info text now occupies the whole row in case there are no page buttons to be rendered