### PR TITLE
Added `collapseIconOnly` to `PanelItem` to collapse sidebar menu item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `collapseIconOnly` to `PanelItem` in order to collapse `PanelSideBarItem` only by clicking on chevron icon and label can work as link
+
+### Added
+
 - PanelSidebar cypress test and toggle it on any screen size
 
 ### Merged

--- a/src/lib/Layout/PanelSideBarLayout/PanelSideBar/Definitions/PanelSideBarMenuItem.ts
+++ b/src/lib/Layout/PanelSideBarLayout/PanelSideBar/Definitions/PanelSideBarMenuItem.ts
@@ -40,4 +40,8 @@ export type PanelItem<TPanelItem = Record<string, unknown>, TMenuItem = Record<s
    * Whether the item is active.
    */
   active?: boolean;
+  /**
+   * Whether collapse only with icon.
+   */
+  collapseIconOnly?: boolean;
 };

--- a/src/lib/Layout/PanelSideBarLayout/PanelSideBar/PanelSideBarItem.tsx
+++ b/src/lib/Layout/PanelSideBarLayout/PanelSideBar/PanelSideBarItem.tsx
@@ -12,12 +12,14 @@ export interface PanelSideBarItemProps {
   depth?: number;
   active?: boolean;
   toggledItemIds: string[];
+  toggledSidebar: boolean;
 }
 
 const PanelSideBarItem = (props: PanelSideBarItemProps) => {
-  const { depth = 0, children: item, LinkRenderer, onClick, toggledItemIds = [] } = props;
+  const { depth = 0, children: item, LinkRenderer, onClick, toggledItemIds = [], toggledSidebar } = props;
 
   const hasitem = !!item.children?.length;
+  const collapseIconOnly = item.collapseIconOnly || item.children?.find(x => x.collapseIconOnly)
   const [isOpen, setIsOpen] = useState(toggledItemIds?.includes(item.id) || item.expanded);
   if (item.display === false) {
     return null;
@@ -32,14 +34,19 @@ const PanelSideBarItem = (props: PanelSideBarItemProps) => {
       >
         {hasitem ? (
           <Row>
-            <Col lg={10} xs={10}>
-              <a role="button" className={classNames("nav-link")}>
-              {item.icon && <FontAwesomeIcon className="me-2" icon={item.icon} />}
-              <div className="text-justify">{item.title}</div>
-            </a>
+            {/* Dropdown label/link */}
+            <Col lg={10} xs={10} onClick={() => !collapseIconOnly && setIsOpen(!isOpen)}>
+              <LinkRenderer item={item}>
+                <span className="nav-link">
+                  {item.icon && <FontAwesomeIcon icon={item.icon} className="me-2" />}
+                  {item.title}
+                </span>
+              </LinkRenderer>
             </Col>
+            {/* Dropdown icon */}
             <Col lg={2} xs={2} onClick={() => setIsOpen(!isOpen)} role="button">
-              <div style={{alignItems: "normal"}} className={classNames("nav-link", { "dropdown-toggle": hasitem })}></div>
+              <div style={{alignItems: "normal", display: toggledSidebar ? "block" : "none"}}
+                   className={classNames("nav-link", { "dropdown-toggle": hasitem })} />
             </Col>
           </Row>
         ) : (
@@ -65,6 +72,7 @@ const PanelSideBarItem = (props: PanelSideBarItemProps) => {
               depth={depth + 1}
               active={item.active}
               toggledItemIds={toggledItemIds}
+              toggledSidebar={toggledSidebar}
             />
           ))}
         </Collapse>

--- a/src/lib/Layout/PanelSideBarLayout/PanelSideBar/PanelSideBarItem.tsx
+++ b/src/lib/Layout/PanelSideBarLayout/PanelSideBar/PanelSideBarItem.tsx
@@ -1,7 +1,7 @@
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import classNames from "classnames";
 import {ComponentType, useState} from "react";
-import { Collapse, NavItem } from "reactstrap";
+import {Collapse, NavItem, Row, Col} from "reactstrap";
 import { LinkRendererProps } from "src/lib/SideBar/SideBarMenuContext";
 import {PanelItem} from "src/lib/Layout/PanelSideBarLayout/PanelSideBar/Definitions/PanelSideBarMenuItem";
 
@@ -31,12 +31,17 @@ const PanelSideBarItem = (props: PanelSideBarItemProps) => {
         style={{ paddingLeft: depth ? `${depth + 1}rem` : undefined }}
       >
         {hasitem ? (
-          <div>
-            <a role="button" className={classNames("nav-link", { "dropdown-toggle": hasitem })} onClick={() => setIsOpen(!isOpen)}>
+          <Row>
+            <Col lg={10} xs={10}>
+              <a role="button" className={classNames("nav-link")}>
               {item.icon && <FontAwesomeIcon className="me-2" icon={item.icon} />}
               <div className="text-justify">{item.title}</div>
             </a>
-          </div>
+            </Col>
+            <Col lg={2} xs={2} onClick={() => setIsOpen(!isOpen)} role="button">
+              <div style={{alignItems: "normal"}} className={classNames("nav-link", { "dropdown-toggle": hasitem })}></div>
+            </Col>
+          </Row>
         ) : (
           <>
             <LinkRenderer item={item}>

--- a/src/lib/Layout/PanelSideBarLayout/PanelSideBar/PanelSidebar.tsx
+++ b/src/lib/Layout/PanelSideBarLayout/PanelSideBar/PanelSidebar.tsx
@@ -5,7 +5,12 @@ import { usePanelSideBarContext } from "./Context/PanelSideBarContext";
 import { PanelItem } from "./Definitions/PanelSideBarMenuItem";
 import { PanelSideBarItem } from "./PanelSideBarItem";
 
-export const PanelSideBar = () => {
+interface PanelSidebarProps {
+    toggledSidebar: boolean;
+}
+
+export const PanelSideBar = (props: PanelSidebarProps) => {
+  const { toggledSidebar } = props;
   const { activePanelId, globalItems, localItems = [], LinkRenderer, setActivePanel, toggledMenuItemIds, toggleMenuItem } = usePanelSideBarContext();
   const panelItems = localItems.concat(globalItems);
 
@@ -51,6 +56,7 @@ export const PanelSideBar = () => {
             LinkRenderer={LinkRenderer}
             onClick={(menuItem) => toggleMenuItem(menuItem)}
             toggledItemIds={toggledMenuItemIds}
+            toggledSidebar={toggledSidebar}
           />
         ))}
       </div>

--- a/src/lib/Layout/PanelSideBarLayout/PanelSideBarLayout.tsx
+++ b/src/lib/Layout/PanelSideBarLayout/PanelSideBarLayout.tsx
@@ -65,8 +65,8 @@ export const PanelSideBarLayout = (props: PanelSideBarLayoutProps) => {
       </nav>
 
       <section className={classNames({ toggled: !isOpen })}>
-        <PanelSideBar />
-        {collapsible === true && <PanelSideBarToggle onClick={toggleSidebar} toggled={!isOpen} />}
+        <PanelSideBar toggledSidebar={isOpen} />
+        {collapsible && <PanelSideBarToggle onClick={toggleSidebar} toggled={!isOpen} />}
         <PanelSideBarLayoutContent footer={footer ?? contextFooter}>{children}</PanelSideBarLayoutContent>
       </section>
     </>


### PR DESCRIPTION
Added `collapseIconOnly` to `PanelItem` in order to collapse `PanelSideBarItem` only by clicking on chevron icon and label can work as link
